### PR TITLE
changed chaining (.attribute) for optional chaining (?.attribute) when accessing PackageJSON.version | PackageJSON.description

### DIFF
--- a/src/cli/bin/cli-bin.ts
+++ b/src/cli/bin/cli-bin.ts
@@ -17,7 +17,7 @@ function CLIErrorHandler(e: Error) {
 async function main() {
   program
     .version(Utils.getPackageVersion())
-    .description('The SCANOSS JS package provides a simple, easy to consume module for interacting with SCANOSS APIs/Engine.')
+    ?.description('The SCANOSS JS package provides a simple, easy to consume module for interacting with SCANOSS APIs/Engine.')
 
   program
     .command('scan <source>')

--- a/src/sdk/Utils/Utils.ts
+++ b/src/sdk/Utils/Utils.ts
@@ -24,7 +24,7 @@ export class Utils {
         if (!this.PackageJSON) break;
       }
     }
-    return this.PackageJSON.version
+    return this.PackageJSON?.version
   }
 
 


### PR DESCRIPTION
This fixes the following bug that comes up when running "scanoss-js scan <file>"

C:\Users\admin\AppData\Roaming\npm\node_modules\scanoss\build\main\sdk\Utils\Utils.js:53
        return this.PackageJSON.version;
                                ^

TypeError: Cannot read properties of null (reading 'version')
    at Function.getPackageVersion (C:\Users\admin\AppData\Roaming\npm\node_modules\scanoss\build\main\sdk\Utils\Utils.js:53:33)
    at main (C:\Users\agust\AppData\Roaming\npm\node_modules\scanoss\build\main\cli\bin\cli-bin.js:15:32)
    at Object.<anonymous> (C:\Users\admin\AppData\Roaming\npm\node_modules\scanoss\build\main\cli\bin\cli-bin.js:63:5)
    at Module._compile (node:internal/modules/cjs/loader:1126:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1180:10)
    at Module.load (node:internal/modules/cjs/loader:1004:32)
    at Function.Module._load (node:internal/modules/cjs/loader:839:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
    at node:internal/main/run_main_module:17:47