### PR TITLE
Fix package.json not being read by getPackageVersion() function

### DIFF
--- a/src/sdk/Utils/Utils.ts
+++ b/src/sdk/Utils/Utils.ts
@@ -16,12 +16,16 @@ export class Utils {
 
   public static getPackageVersion(): string {
     if (!this.PackageJSON) {
-      const packageJsonPaths = ['../../../package.json', '../../../../package.json'];
-      for (const packageJsonPath in packageJsonPaths) {
+      const path = require('path');
+      const possiblePackageJsonPaths = [
+        path.join(__dirname, '../../../../package.json'),
+        path.join(__dirname, '../../../package.json')
+      ];
+      for (const packageJsonPath of possiblePackageJsonPaths) {
         try {
           this.PackageJSON = require(packageJsonPath);
         } catch (e) {}
-        if (!this.PackageJSON) break;
+        if (this.PackageJSON) break;
       }
     }
     return this.PackageJSON.version


### PR DESCRIPTION
Fix package.json reading issue by updating getPackageVersion() method to use absolute file paths. The previous implementation relied on relative file paths, which caused the method to fail in certain cases. This PR replaces the old code with a new implementation that uses path.join() to construct the absolute file paths and iterates over all possible paths until it finds a valid package.json file. This change ensures that the getPackageVersion() method works correctly in all scenarios.