### PR TITLE
chore:SP-3131 Removes 'api' prefix from dependency and vulnerability …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [0.19.0] (2025-08-29)
+### Changed
+- Removed `api` prefix from dependency and vulnerability API URLs
+### Fixed
+- Fixed license field mapping for dependency responses (spdx_id, is_spdx_approved)  
+
 ## [0.18.0] (2025-08-28)
 ### Added 
 - Added REST protocol implementation for SCANOSS dependency service
@@ -109,4 +115,5 @@ All notable changes to this project will be documented in this file. See [standa
 ### [0.17.1](https://github.com/scanoss/scanoss.js/compare/v0.17.0...v0.17.1) (2025-06-16)
 ### [0.17.2](https://github.com/scanoss/scanoss.js/compare/v0.17.1...v0.17.2) (2025-06-25)
 ### [0.17.3](https://github.com/scanoss/scanoss.js/compare/v0.17.2...v0.17.3) (2025-06-27)
-### [0.17.4](https://github.com/scanoss/scanoss.js/compare/v0.17.3...v0.17.4) (2025-08-27)
+### [0.18.0](https://github.com/scanoss/scanoss.js/compare/v0.17.3...v0.18.0) (2025-08-28)
+### [0.19.0](https://github.com/scanoss/scanoss.js/compare/v0.18.0...v0.19.0) (2025-08-29)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scanoss",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "The SCANOSS JS package provides a simple, easy to consume module for interacting with SCANOSS APIs/Engine.",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/cli/bin/cli-bin.ts
+++ b/src/cli/bin/cli-bin.ts
@@ -49,6 +49,7 @@ async function main() {
   scan.addOption(new Option("-v, --verbose", "Makes scan operation verbose"));
   scan.addOption(new Option("-st, --settings <filename>", "Settings file to use for scanning (optional - default scanoss.json)"));
   scan.addOption(new Option("-stf, --skip-settings-file", "Skips settings file"));
+  scan.addOption(new Option("    --debug", "Enables debugging"));
 
   scan.action((source, options) => {
     scanHandler(source, options).catch((e) => {

--- a/src/cli/commands/scan.ts
+++ b/src/cli/commands/scan.ts
@@ -26,9 +26,12 @@ import { CryptoCfg } from "../../sdk/Cryptography/CryptoCfg";
 import { CryptographyScanner } from "../../sdk/Cryptography/CryptographyScanner";
 import { CryptographyResponse, LocalCryptography } from "../../sdk/Cryptography/CryptographyTypes";
 import { DependencyResponse } from "../../sdk/Clients/Dependency/IDependencyClient";
+import { Logger, logger } from "../../sdk/Logger";
 
 export async function scanHandler(rootPath: string, options: any): Promise<void> {
-  // TODO: Add flag to enable debug. False by default.  logger.enableDebug(options.debug);
+  logger.setLevel(Logger.Level.info);
+  if(options.debug)
+    logger.setLevel(Logger.Level.debug);
   rootPath = path.resolve(rootPath);
   const pathIsFolder = await isFolder(rootPath);
   const projectName = getProjectNameFromPath(rootPath);
@@ -97,7 +100,7 @@ export async function scanHandler(rootPath: string, options: any): Promise<void>
 
   if (!options.wfp) {
     if (pathIsFolder) {
-      console.error("\nReading directory...  ");
+      logger.debug(`Reading directory ${rootPath}...`);
       const tree = new Tree(rootPath);
       tree.build();
 

--- a/src/sdk/Clients/Dependency/DependencyHttpClient.ts
+++ b/src/sdk/Clients/Dependency/DependencyHttpClient.ts
@@ -20,7 +20,7 @@ export class DependencyHttpClient extends HttpClient implements IDependencyClien
 
   public async getDependencies(req: DependencyRequest): Promise<DependencyResponse> {
     try{
-      const response = await this.client.post(`${this.baseUrl}/api/v2/dependencies/dependencies`, req);
+      const response = await this.client.post(`${this.baseUrl}/v2/dependencies/dependencies`, req);
       if (response.ok) {
         return this.toDependencyResponse(await response.json());
       }
@@ -44,8 +44,8 @@ export class DependencyHttpClient extends HttpClient implements IDependencyClien
         version: dep.version,
         licensesList: dep.licenses.map(license => ({
           name: license.name,
-          spdxId: license.spdxId,
-          isSpdxApproved: license.isSpdxApproved,
+          spdxId: license.spdx_id,
+          isSpdxApproved: license.is_spdx_approved,
           url: license.url
         })),
         url: dep.url,

--- a/src/sdk/Clients/Grpc/BaseGRPCClient.ts
+++ b/src/sdk/Clients/Grpc/BaseGRPCClient.ts
@@ -49,25 +49,19 @@ export class BaseGRPCClient {
   }) {
     const { status, ...responseWithoutStatus } = response;
     if (status.status === CommonMessages.StatusCode.FAILED) {
-      logger.log(
-        `[ GRPC ${this._CLIENT_NAME} ] - Server GRPC Code: ${status.status} - ${status.message}`,
-        Level.error
-      );
+      logger.error(
+        `[ GRPC ${this._CLIENT_NAME} ] - Server GRPC Code: ${status.status} - ${status.message}`);
       throw new Error(status.message);
     } else if (
       status.status === CommonMessages.StatusCode.WARNING ||
       status.status === CommonMessages.StatusCode.SUCCEEDED_WITH_WARNINGS ||
       status.status === CommonMessages.StatusCode.UNSPECIFIED
     ) {
-      logger.log(
-        `[ GRPC ${this._CLIENT_NAME} ] - Server GRPC Code: ${status.status} - ${status.message}`,
-        Level.warn
-      );
+      logger.debug(
+        `[ GRPC ${this._CLIENT_NAME} ] - Server GRPC Code: ${status.status} - ${status.message}`);
     } else if (status.status === CommonMessages.StatusCode.SUCCESS) {
-      logger.log(
-        `[ GRPC ${this._CLIENT_NAME} ] - Server GRPC Code: ${status.status} - ${status.message}`,
-        Level.info
-      );
+      logger.debug(
+        `[ GRPC ${this._CLIENT_NAME} ] - Server GRPC Code: ${status.status} - ${status.message}`);
     }
 
     return responseWithoutStatus;

--- a/src/sdk/Clients/Vulnerability/VulnerabilityHttpClient.ts
+++ b/src/sdk/Clients/Vulnerability/VulnerabilityHttpClient.ts
@@ -20,7 +20,7 @@ export class VulnerabilityHttpClient extends HttpClient implements IVulnerabilit
 
   public async getVulnerabilitiesComponents(components: Array<Component>): Promise<any> {
     try{
-      const response = await this.client.post(`${this.baseUrl}/api/v2/vulnerabilities/components`, components);
+      const response = await this.client.post(`${this.baseUrl}/v2/vulnerabilities/components`, components);
       if (response.ok) {
         const vulnerabilities = await response.json();
         return vulnerabilities;


### PR DESCRIPTION
## WHAT

### Changed
- Removed `api` prefix from dependency and vulnerability API URLs
### Fixed
- Fixed license field mapping for dependency responses (spdx_id, is_spdx_approved)  