### PR TITLE
Chore/use http client for crypto scanning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+
+## [0.22.0] (2025-09-05)
+### Changed
+- Removed `api` prefix from dependency and vulnerability API URLs
+### Fixed
+- Fixed license field mapping for dependency responses (spdx_id, is_spdx_approved)
+
 ## [0.21.1] (2025-09-03)
 ### Changed
 - Keep basic compatability across all the scanners
@@ -18,12 +25,12 @@ All notable changes to this project will be documented in this file. See [standa
 ### Changed
 - switched cryptography scanner over to use cryptography http client
 
-
 ## [0.19.0] (2025-08-29)
 ### Changed
-- Removed `api` prefix from dependency and vulnerability API URLs
-### Fixed
-- Fixed license field mapping for dependency responses (spdx_id, is_spdx_approved)  
+- Used HTTP protocol for cryptography scanning
+- Implemented ´ClientConfig´ on ´VulnerabilityHttpClient.ts´, ´CryptographyHttpClient.ts´ and ´DependencyHttpClient.ts´files
+### Added
+- Added documentation about deprecated scanner configuration
 
 ## [0.18.0] (2025-08-28)
 ### Added 
@@ -137,3 +144,4 @@ All notable changes to this project will be documented in this file. See [standa
 ### [0.20.0](https://github.com/scanoss/scanoss.js/compare/v0.18.0...v0.19.0) (2025-09-02)
 ### [0.21.0](https://github.com/scanoss/scanoss.js/compare/v0.18.0...v0.19.0) (2025-09-03)
 ### [0.21.1](https://github.com/scanoss/scanoss.js/compare/v0.18.0...v0.19.0) (2025-09-03)
+### [0.22.0](https://github.com/scanoss/scanoss.js/compare/v0.18.0...v0.19.0) (2025-09-05)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scanoss",
-  "version": "0.21.1",
+  "version": "0.22.0",
   "description": "The SCANOSS JS package provides a simple, easy to consume module for interacting with SCANOSS APIs/Engine.",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/cli/commands/scan.ts
+++ b/src/cli/commands/scan.ts
@@ -178,9 +178,16 @@ export async function scanHandler(rootPath: string, options: any): Promise<void>
     if(options.key) cfg.API_KEY = options.key;
     if (options.caCert) cfg.CA_CERT = options.caCert;
     if (options.ignoreCertErrors) cfg.IGNORE_CERT_ERRORS = true;
+    if (options.proxy) {
+      cfg.HTTPS_PROXY = options.proxy;
+      cfg.HTTP_PROXY = options.proxy;
+    }
     if (options.apiurl) cfg.API_URL = options.apiurl;
-    if (options.api2url) cfg.API_URL = options.apiurl;
-    if(options.grpc_proxy) cfg.GRPC_PROXY = options.grpc_proxy;
+
+    //TODO: Deprecated. Remove gRPC config on v1 version.
+    if (options.api2url) cfg.API_URL = options.apiurl; //TODO: Deprecated. Remove on v1 version
+    if(options.grpc_proxy) cfg.GRPC_PROXY = options.grpc_proxy; //TODO: Deprecated. Remove on v1 version
+
     const cryptoScanner = new CryptographyScanner(cfg);
 
 

--- a/src/sdk/BaseConfig.ts
+++ b/src/sdk/BaseConfig.ts
@@ -17,7 +17,9 @@ export abstract class BaseConfig {
   /** API URL for service connections */
   private _API_URL: string = '';
 
-  /** gRPC proxy server URL */
+  /** gRPC proxy server URL
+   * @deprecated since v0.20.1 - Use HTTP_PROXY or HTTPS_PROXY instead. Will be removed in v1
+   * */
   private _GRPC_PROXY: string = '';
 
   /** Path to the CA certificate file for SSL/TLS connections */
@@ -118,6 +120,7 @@ export abstract class BaseConfig {
   /**
    * Sets the gRPC proxy server URL.
    * @param value - gRPC proxy URL
+   * @deprecated since v0.20.1 - Use HTTP_PROXY or HTTPS_PROXY instead. Will be removed in v1
    */
   set GRPC_PROXY(value: string) {
     this._GRPC_PROXY = value;
@@ -180,6 +183,7 @@ export abstract class BaseConfig {
 
   /**
    * Gets the gRPC proxy server URL.
+   * @deprecated since v0.20.1 - Use HTTP_PROXY or HTTPS_PROXY instead. Will be removed in v1
    * @returns gRPC proxy URL
    */
   get GRPC_PROXY(): string {

--- a/src/sdk/Clients/Cryptography/CryptographyHttpClient.ts
+++ b/src/sdk/Clients/Cryptography/CryptographyHttpClient.ts
@@ -1,4 +1,4 @@
-import { HttpClient } from "../http/HttpClient";
+import { ClientConfig, HttpClient } from "../http/HttpClient";
 import { logger } from "../../Logger";
 import {
   ICryptographyClient,
@@ -7,26 +7,17 @@ import {
 } from "./ICryptographyClient";
 import { validateComponents } from "../helper/clientHelper";
 import { Component } from "../../types/common/types";
+
 export class CryptographyHttpClient extends HttpClient implements ICryptographyClient {
-
-  private client: HttpClient;
-  private readonly baseUrl: string;
-
-  constructor(token: string, hostName: string, proxyHost?: string, caCertPath?: string) {
-    super();
-    this.client = new HttpClient({
-      HOST_URL: hostName,
-      API_KEY: token,
-      HTTPS_PROXY: proxyHost,
-      CA_CERT: caCertPath,
-    });
-    this.baseUrl = hostName;
+  constructor(clientConfig: ClientConfig) {
+    super(clientConfig);
   }
 
   public async getAlgorithms(components: Component[]): Promise<AlgorithmResponse> {
     try {
+      const baseURL = this.hostURL();
       validateComponents(components);
-      const response = await this.client.post(`${this.baseUrl}/v2/cryptography/algorithms`, { purls: components });
+      const response = await this.post(`${baseURL}/v2/cryptography/algorithms`, { purls: components });
 
       if (response.ok) {
         const algorithms = await response.json();
@@ -45,8 +36,9 @@ export class CryptographyHttpClient extends HttpClient implements ICryptographyC
 
   public async getEncryptionHints(components: Component[]): Promise<HintsInRangeResponse> {
     try {
+      const baseURL = this.hostURL();
       validateComponents(components);
-      const response = await this.client.post(`${this.baseUrl}/v2/cryptography/hintsInRange`, { purls: components });
+      const response = await this.post(`${baseURL}/v2/cryptography/hintsInRange`, { purls: components });
 
       if (response.ok) {
         const hints = await response.json();

--- a/src/sdk/Clients/Dependency/DependencyHttpClient.ts
+++ b/src/sdk/Clients/Dependency/DependencyHttpClient.ts
@@ -1,26 +1,15 @@
-import { HttpClient } from "../http/HttpClient";
+import { ClientConfig, HttpClient } from "../http/HttpClient";
 import { DependencyRequest, DependencyResponse, IDependencyClient } from "./IDependencyClient";
 
 export class DependencyHttpClient extends HttpClient implements IDependencyClient {
-
-  private client: HttpClient;
-  private readonly baseUrl: string;
-
-  constructor(token: string, hostName: string, ignoreCertErrors: boolean = false,proxyHost?: string, caCertPath?: string) {
-    super();
-    this.client = new HttpClient({
-      HOST_URL: hostName,
-      API_KEY: token,
-      HTTPS_PROXY: proxyHost,
-      CA_CERT: caCertPath,
-      IGNORE_CERT_ERRORS: ignoreCertErrors
-    });
-    this.baseUrl = hostName;
+  constructor(clientConfig: ClientConfig) {
+    super(clientConfig);
   }
 
   public async getDependencies(req: DependencyRequest): Promise<DependencyResponse> {
     try{
-      const response = await this.client.post(`${this.baseUrl}/v2/dependencies/dependencies`, req);
+      const baseURL = this.hostURL();
+      const response = await this.post(`${baseURL}/v2/dependencies/dependencies`, req);
       if (response.ok) {
         return this.toDependencyResponse(await response.json());
       }

--- a/src/sdk/Clients/Transport/Transport.ts
+++ b/src/sdk/Clients/Transport/Transport.ts
@@ -2,12 +2,12 @@ import FormData from 'form-data';
 
 export abstract class Transport<T1> {
 
-  abstract get(url: string): Promise<T1>;
+  protected abstract get(url: string): Promise<T1>;
 
-  abstract post(url: string, body: FormData): Promise<T1>;
+  protected abstract post(url: string, body: FormData): Promise<T1>;
 
-  abstract put(url: string, body: FormData): Promise<T1>;
+  protected abstract put(url: string, body: FormData): Promise<T1>;
 
-  abstract delete(url: string): Promise<T1>;
+  protected abstract delete(url: string): Promise<T1>;
 
 }

--- a/src/sdk/Clients/Vulnerability/VulnerabilityHttpClient.ts
+++ b/src/sdk/Clients/Vulnerability/VulnerabilityHttpClient.ts
@@ -1,29 +1,20 @@
-import { HttpClient } from "../http/HttpClient";
+import { ClientConfig, HttpClient } from "../http/HttpClient";
 import { IVulnerabilityClient } from "./IVulnerabilityClient";
 import { logger } from "../../Logger";
 import { Component } from "../../types/common/types";
 import { ComponentsVulnerabilitiesResponse, ComponentVulnerabilityResponse } from "../../types/vulnerability/types";
 
 export class VulnerabilityHttpClient extends HttpClient implements IVulnerabilityClient{
-  private client: HttpClient;
-  private readonly baseUrl: string;
 
-  constructor(token: string, hostName: string, ignoreCertErrors: boolean = false ,proxyHost?: string, caCertPath?: string) {
-    super();
-    this.client = new HttpClient({
-      HOST_URL: hostName,
-      API_KEY: token,
-      HTTPS_PROXY: proxyHost,
-      CA_CERT: caCertPath,
-      IGNORE_CERT_ERRORS: ignoreCertErrors
-    });
-    this.baseUrl = hostName;
+  constructor(clientConfig: ClientConfig) {
+    super(clientConfig);
   }
 
   public async getVulnerabilitiesComponents(components: Array<Component>): Promise<ComponentsVulnerabilitiesResponse> {
     try {
+      const baseURL = this.hostURL();
       logger.debug(`Getting vulnerabilities for ${components.map((c)=> JSON.stringify(c,null,2))} components`);
-      const response = await this.client.post(`${this.baseUrl}/v2/vulnerabilities/components`, { components: components });
+      const response = await this.post(`${baseURL}/v2/vulnerabilities/components`, { components: components });
       if (response.ok) {
         return await response.json() as ComponentsVulnerabilitiesResponse;
       }
@@ -37,12 +28,13 @@ export class VulnerabilityHttpClient extends HttpClient implements IVulnerabilit
 
   public async getVulnerabilitiesComponent(component: Component): Promise<ComponentVulnerabilityResponse> {
     try {
+      const baseURL = this.hostURL();
       const queryParams = new URLSearchParams();
       queryParams.append('purl', component.purl);
       if (component.requirement) {
         queryParams.append('requirement', component.requirement);
       }
-      const response =  await this.client.get(`${this.baseUrl}/api/v2/vulnerabilities/component?${queryParams.toString()}`);
+      const response =  await this.get(`${baseURL}/api/v2/vulnerabilities/component?${queryParams.toString()}`);
       if (response.ok) {
         return await response.json() as ComponentVulnerabilityResponse;
       }

--- a/src/sdk/Clients/http/HttpClient.ts
+++ b/src/sdk/Clients/http/HttpClient.ts
@@ -4,7 +4,7 @@ import { Transport } from '../Transport/Transport';
 import { Utils } from '../../Utils/Utils';
 import FormData from 'form-data';
 
-export interface HttpProxyConfig {
+export interface ClientConfig {
     PAC_PROXY?: string;
     API_KEY?: string;
     NO_PROXY?: string;
@@ -17,9 +17,9 @@ export interface HttpProxyConfig {
 export class HttpClient extends Transport<Response>  {
 
     private readonly proxyAgent: ProxyAgent;
-    protected cfg: HttpProxyConfig;
+    protected cfg: ClientConfig;
 
-    constructor(cfg?: HttpProxyConfig){
+    constructor(cfg?: ClientConfig){
       super();
       this.cfg = cfg;
       this.init();
@@ -50,7 +50,7 @@ export class HttpClient extends Transport<Response>  {
       if (caCertPath) Utils.loadCaCertFromFile(caCertPath);
     }
 
-    async get(url: string): Promise<Response> {
+    protected async get(url: string): Promise<Response> {
         return await fetch(url, {
             agent: this.proxyAgent,
             method: 'get',
@@ -60,7 +60,7 @@ export class HttpClient extends Transport<Response>  {
         });
     }
 
-  async post(url: string, body: any): Promise<Response> {
+  protected async post(url: string, body: any): Promise<Response> {
     return await fetch(url, {
       agent: this.proxyAgent,
       method: 'post',
@@ -72,7 +72,7 @@ export class HttpClient extends Transport<Response>  {
     });
   }
 
-  async delete(url: string): Promise<Response> {
+  protected async delete(url: string): Promise<Response> {
     return await fetch(url, {
       agent: this.proxyAgent,
       method: 'delete',
@@ -82,7 +82,7 @@ export class HttpClient extends Transport<Response>  {
     });
   }
 
-  async put(url: string, body: FormData): Promise<Response> {
+  protected async put(url: string, body: FormData): Promise<Response> {
     return await fetch(url, {
       agent: this.proxyAgent,
       method: 'put',
@@ -98,5 +98,9 @@ export class HttpClient extends Transport<Response>  {
       return new Error(`${context}: ${error.message}`);
     }
     return new Error(`${context}: Unknown error occurred`);
+  }
+
+  protected hostURL():string {
+      return this.cfg.HOST_URL;
   }
 }

--- a/src/sdk/Cryptography/Algorithm/Components/ComponentAlgorithmScanner.ts
+++ b/src/sdk/Cryptography/Algorithm/Components/ComponentAlgorithmScanner.ts
@@ -5,7 +5,8 @@ import {
 import { BaseCryptographyScanner } from "../../BaseCryptographyScanner";
 import { AlgorithmResponse } from "../../../Clients/Cryptography/ICryptographyClient";
 import { Component } from "../../../types/common/types";
-import { CryptographyGRPCClient } from "../../../Clients/Cryptography/CryptographyGRPCClient";
+import { CryptographyHttpClient } from "../../../Clients/Cryptography/CryptographyHttpClient";
+import { ClientConfig } from "../../../Clients/http/HttpClient";
 
 /**
  * Scanner for detecting cryptographic algorithms in software components.
@@ -26,11 +27,11 @@ export class ComponentAlgorithmScanner
    * @returns {AlgorithmResponse} A promise that resolves to an AlgorithmResponse containing detected cryptographic algorithms.
    */
   public async scan(components: Component[]):Promise<AlgorithmResponse> {
-    const cryptographyClient = new CryptographyGRPCClient(
-      this.config.API_KEY, // API KEY
-      this.config.API_URL, // Destination Host
-      this.config.GRPC_PROXY, // Proxy Host
-      this.config.CA_CERT);
+    const clientCfg: ClientConfig = {
+      ...this.config,
+      HOST_URL: this.config.API_URL, // Only map the one that differs. TODO: Migrate to HOST URL on v1 version
+    };
+    const cryptographyClient = new CryptographyHttpClient(clientCfg);
     const results:AlgorithmResponse = await cryptographyClient.getAlgorithms(components);
     this.resultCollector.collectAlgorithmResults(results);
     return results;

--- a/src/sdk/Cryptography/Hint/Components/ComponentHintScanner.ts
+++ b/src/sdk/Cryptography/Hint/Components/ComponentHintScanner.ts
@@ -4,7 +4,8 @@ import {
 import { BaseCryptographyScanner } from "../../BaseCryptographyScanner";
 import { HintsInRangeResponse } from "../../../Clients/Cryptography/ICryptographyClient";
 import { Component } from "../../../types/common/types";
-import { CryptographyGRPCClient } from "../../../Clients/Cryptography/CryptographyGRPCClient";
+import { CryptographyHttpClient } from "../../../Clients/Cryptography/CryptographyHttpClient";
+import { ClientConfig } from "../../../Clients/http/HttpClient";
 
 /**
  * Scanner for detecting cryptographic hints in software components.
@@ -24,12 +25,12 @@ export class ComponentHintScanner
    * @param req A request containing PURL (Package URL) identifiers for components to scan.
    * @returns {HintsResponse} A promise that resolves to a HintsResponse containing detected cryptographic hints.
    */
-  public async scan(req: Component[]):Promise<HintsInRangeResponse>{
-    const cryptographyClient = new CryptographyGRPCClient(
-      this.config.API_KEY, // API KEY
-      this.config.API_URL, // Destination Host
-      this.config.GRPC_PROXY, // Proxy Host
-      this.config.CA_CERT);
+  public async scan(req: Component[]):Promise<HintsInRangeResponse> {
+    const clientCfg: ClientConfig = {
+      ...this.config,
+      HOST_URL: this.config.API_URL, // Only map the one that differs. TODO: Migrate to HOST URL on v1 version
+    };
+    const cryptographyClient = new CryptographyHttpClient(clientCfg);
     const results = await cryptographyClient.getEncryptionHints(req);
     this.resultCollector.collectHintResults(results);
     return results;

--- a/src/sdk/Dependencies/DependencyScanner.ts
+++ b/src/sdk/Dependencies/DependencyScanner.ts
@@ -12,6 +12,7 @@ import {
   IDependencyClient,
   Status
 } from "../Clients/Dependency/IDependencyClient";
+import { ClientConfig } from "../Clients/http/HttpClient";
 
 export class DependencyScanner {
   private localDependency: LocalDependencies;
@@ -23,8 +24,12 @@ export class DependencyScanner {
   constructor(cfg?: DependencyScannerCfg) {
     if (cfg) this.config = cfg;
     else this.config = new DependencyScannerCfg();
-    this.dependencyClient = new DependencyHttpClient(this.config.API_KEY, this.config.API_URL,this.config.IGNORE_CERT_ERRORS,
-      this.config.HTTPS_PROXY, this.config.CA_CERT);
+
+    const clientCfg: ClientConfig = {
+      ...this.config,
+      HOST_URL: this.config.API_URL, // Only map the one that differs. TODO: Migrate to HOST URL on v1 version
+    };
+    this.dependencyClient = new DependencyHttpClient(clientCfg);
     this.localDependency = new LocalDependencies();
   }
 

--- a/src/sdk/Vulnerability/VulnerabilityScanner.ts
+++ b/src/sdk/Vulnerability/VulnerabilityScanner.ts
@@ -8,7 +8,7 @@ import {
   ComponentVulnerabilityResponse
 } from "../types/vulnerability/types";
 import { Component } from "../types/common/types";
-
+import { ClientConfig } from "../Clients/http/HttpClient";
 
 export class VulnerabilityScanner {
   private config: VulnerabilityCfg;
@@ -18,13 +18,11 @@ export class VulnerabilityScanner {
   constructor(config?: VulnerabilityCfg) {
     if (config) this.config = config;
     else this.config = new VulnerabilityCfg();
-    this.vulnerabilityClient = new VulnerabilityHttpClient(
-      this.config.API_KEY,
-      this.config.API_URL ? this.config.API_URL : '',
-      this.config.IGNORE_CERT_ERRORS,
-      this.config.HTTPS_PROXY ? this.config.HTTPS_PROXY : '',
-      this.config.CA_CERT
-    );
+    const clientCfg: ClientConfig = {
+      ...this.config,
+      HOST_URL: this.config.API_URL, // Only map the one that differs. TODO: Migrate to HOST URL on v1 version
+    };
+    this.vulnerabilityClient = new VulnerabilityHttpClient(clientCfg);
   }
 
   public async getVulnerabilitiesComponents(components: Array<Component>): Promise<ComponentsVulnerabilitiesResponse>{


### PR DESCRIPTION
## What's Changed

### Changed
- Used HTTP protocol for cryptography scanning
- Implemented ´ClientConfig´ on ´VulnerabilityHttpClient.ts´, ´CryptographyHttpClient.ts´ and ´DependencyHttpClient.ts´files
### Added
- Added documentation about deprecated scanner configuration

