### PR TITLE
fix/SP-4227/decompress-unc-paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file. See [standa
 
 ## [Unreleased]
 
+## [0.38.1] (2026-04-08)
+### Fixed
+- Fixed decompression failing on Windows when scanning from UNC network paths (e.g. `\\server\share\...`). The `adm-zip` library internally calls `fs.chmodSync()` after extracting each file, which fails with `ENOENT` on UNC paths. Replaced with manual entry extraction to avoid the unnecessary chmod call.
+
 ## [0.38.0] (2026-03-12)
 ### Added
 - Added support for resolving Gradle dependencies from version catalog (`libs.versions.toml`)
@@ -287,3 +291,5 @@ All notable changes to this project will be documented in this file. See [standa
 ### [0.35.0](https://github.com/scanoss/scanoss.js/compare/v0.34.0...v0.35.0) (2026-02-26)
 ### [0.36.0](https://github.com/scanoss/scanoss.js/compare/v0.35.0...v0.36.0) (2026-02-27)
 ### [0.37.0](https://github.com/scanoss/scanoss.js/compare/v0.36.0...v0.37.0) (2026-03-02)
+### [0.38.0](https://github.com/scanoss/scanoss.js/compare/v0.37.0...v0.38.0) (2026-03-12)
+### [0.38.1](https://github.com/scanoss/scanoss.js/compare/v0.38.0...v0.38.1) (2026-04-08)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "scanoss",
-  "version": "0.32.0",
+  "version": "0.38.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scanoss",
-  "version": "0.38.0",
+  "version": "0.38.1",
   "description": "The SCANOSS JS package provides a simple, easy to consume module for interacting with SCANOSS APIs/Engine.",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/sdk/Decompress/Decompressor/DecompressZips.ts
+++ b/src/sdk/Decompress/Decompressor/DecompressZips.ts
@@ -1,3 +1,6 @@
+import path from 'path';
+import fs from 'fs';
+
 import { Decompressor } from './Decompressor';
 import AdmZip from 'adm-zip';
 
@@ -14,9 +17,21 @@ export class DecompressZip extends Decompressor{
     ]
   }
 
+  // Extract entries manually to avoid adm-zip's internal fs.chmodSync() call,
+  // which fails on Windows UNC paths (\\server\share\...) with ENOENT.
+  // See: https://github.com/cthackers/adm-zip/issues/162
   public async run(archivePath: string, destPath: string): Promise<void> {
     const zip = new AdmZip(archivePath);
-    zip.extractAllTo(destPath);
+    const entries = zip.getEntries();
+    for (const entry of entries) {
+      const entryPath = path.join(destPath, entry.entryName);
+      if (entry.isDirectory) {
+        fs.mkdirSync(entryPath, { recursive: true });
+      } else {
+        fs.mkdirSync(path.dirname(entryPath), { recursive: true });
+        fs.writeFileSync(entryPath, entry.getData());
+      }
+    }
   }
 
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed decompression failures on Windows UNC network paths.

* **Chores**
  * Bumped version to 0.38.1.
  * Updated changelog with latest fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->