### PR TITLE
feat/SP-4273/recursive-decompress-skipped-reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
 ## [Unreleased]
+
+## [0.39.0] (2026-04-23)
 ### Added
 - `DecompressionManager.decompress()` now returns `skippedByDepth: Array<string>`, a list of supported archive paths encountered beyond `decompressionLevel` and therefore not expanded. Allows callers to report which nested archives were left unexpanded.
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
 ## [Unreleased]
+### Added
+- `DecompressionManager.decompress()` now returns `skippedByDepth: Array<string>`, a list of supported archive paths encountered beyond `decompressionLevel` and therefore not expanded. Allows callers to report which nested archives were left unexpanded.
+### Changed
+- **BREAKING:** `DecompressionManager.decompressRecursive()` return type changed from `Array<{path, error}>` to `{ failedFiles: Array<{path, error}>, skippedByDepth: Array<string> }`. Callers consuming this method directly must update to read `.failedFiles`.
 
 ## [0.38.1] (2026-04-08)
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scanoss",
-  "version": "0.38.1",
+  "version": "0.39.0",
   "description": "The SCANOSS JS package provides a simple, easy to consume module for interacting with SCANOSS APIs/Engine.",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/sdk/Decompress/DecompressionManager.ts
+++ b/src/sdk/Decompress/DecompressionManager.ts
@@ -44,68 +44,74 @@ export class DecompressionManager {
     return supportedFormats;
   }
 
-  public async decompress(archivesPaths: Array<string>): Promise<{ parentFolders: Array<string>, failedFiles: Array<{ path: string, error: string }> }> {
+  public async decompress(archivesPaths: Array<string>): Promise<{ parentFolders: Array<string>, failedFiles: Array<{ path: string, error: string }>, skippedByDepth: Array<string> }> {
     const failedFiles: Array<{ path: string, error: string }> = [];
+    const skippedByDepth: Array<string> = [];
     for (const archivePath of archivesPaths) {
-      const failed = await this.decompressRecursive(archivePath, 0);
-      failedFiles.push(...failed);
+      const result = await this.decompressRecursive(archivePath, 0);
+      failedFiles.push(...result.failedFiles);
+      skippedByDepth.push(...result.skippedByDepth);
     }
     const parentFolders = archivesPaths.map(archivePath => `${archivePath}${this.suffix}`);
-    return { parentFolders, failedFiles };
+    return { parentFolders, failedFiles, skippedByDepth };
   }
 
 
-  public async decompressRecursive(archivePath: string, level: number): Promise<Array<{ path: string, error: string }>> {
+  public async decompressRecursive(archivePath: string, level: number): Promise<{ failedFiles: Array<{ path: string, error: string }>, skippedByDepth: Array<string> }> {
     const failedFiles: Array<{ path: string, error: string }> = [];
+    const skippedByDepth: Array<string> = [];
 
-    if(level>=this.decompressionLevel) return failedFiles;
+    const archiveName = path.basename(archivePath);
+    const isSupported = this.decompressorList.some((d) => d.isSupported(archiveName));
+    if (!isSupported) return { failedFiles, skippedByDepth };
+
+    // Supported archive but configured depth exceeded — record and stop
+    if (level >= this.decompressionLevel) {
+      skippedByDepth.push(archivePath);
+      return { failedFiles, skippedByDepth };
+    }
 
     const archiveRootPath = path.dirname(archivePath);
-    const archiveName = path.basename(archivePath);
     let newFolderPath = `${archiveRootPath}${path.sep}${archiveName}${this.suffix}`;
 
-    const isSupported = this.decompressorList.some((d) => d.isSupported(archiveName))
-    if(isSupported) {
+    let i = 0;
+    const r = new RegExp("(?<=" + this.suffix +")-\\d+$")  //Selects last -X where X is a number
+    while( !this.decompressOverride && fs.existsSync(newFolderPath) ) { //Search for a free name
+      newFolderPath = newFolderPath.replace(r, "");
+      newFolderPath += `-${i}`
+      i++;
+    }
 
-
-      let i = 0;
-      const r = new RegExp("(?<=" + this.suffix +")-\\d+$")  //Selects last -X where X is a number
-      while( !this.decompressOverride && fs.existsSync(newFolderPath) ) { //Search for a free name
-        newFolderPath = newFolderPath.replace(r, "");
-        newFolderPath += `-${i}`
-        i++;
-      }
-
-      await fs.promises.mkdir(newFolderPath, { recursive: true });
-      //Search for decompressor and extract archive
-      let extractionFailed = false;
-      for (const d of this.decompressorList) {
-        if (d.isSupported(archiveName)) {
-          try{
-            await d.run(archivePath, newFolderPath);
-          } catch(e) {
-            await fs.promises.rm(newFolderPath, {recursive: true, force: true});
-            const message = e instanceof Error ? e.message : String(e);
-            failedFiles.push({ path: archivePath, error: message });
-            extractionFailed = true;
-          }
-          break;
+    await fs.promises.mkdir(newFolderPath, { recursive: true });
+    //Search for decompressor and extract archive
+    let extractionFailed = false;
+    for (const d of this.decompressorList) {
+      if (d.isSupported(archiveName)) {
+        try{
+          await d.run(archivePath, newFolderPath);
+        } catch(e) {
+          await fs.promises.rm(newFolderPath, {recursive: true, force: true});
+          const message = e instanceof Error ? e.message : String(e);
+          failedFiles.push({ path: archivePath, error: message });
+          extractionFailed = true;
         }
-      }
-
-      //Search for new archives (only if extraction succeeded)
-      if (!extractionFailed) {
-        const tree = new Tree(newFolderPath);
-        tree.build()
-        const newFilesPath = tree.getFileList(new DecompressionFilter(""));
-        for (const newFilePath of newFilesPath) {
-          const nestedFailed = await this.decompressRecursive(newFilePath, level+1);
-          failedFiles.push(...nestedFailed);
-        }
+        break;
       }
     }
 
-    return failedFiles;
+    //Search for new archives (only if extraction succeeded)
+    if (!extractionFailed) {
+      const tree = new Tree(newFolderPath);
+      tree.build()
+      const newFilesPath = tree.getFileList(new DecompressionFilter(""));
+      for (const newFilePath of newFilesPath) {
+        const nested = await this.decompressRecursive(newFilePath, level+1);
+        failedFiles.push(...nested.failedFiles);
+        skippedByDepth.push(...nested.skippedByDepth);
+      }
+    }
+
+    return { failedFiles, skippedByDepth };
   }
 
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Version 0.39.0: Decompression now tracks and reports archives skipped when the configured depth limit is reached.

* **Breaking Changes**
  * Decompression recursive method return format updated; callers must adapt code to handle the new result structure containing failed files and skipped archives information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->