### PR TITLE
Fix/sp 4350 skip fh2 winnowing hpsm binary files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
 ## [Unreleased]
+### Fixed
+- `WfpCalculator` no longer crashes with `RangeError: Invalid array length` when fingerprinting large binary files.
+- `scanoss-js wfp` CLI now uses `ScanFilter` instead of `DependencyFilter` when building the file list
+### Changed
+- `WfpCalculator` now detects binary files via `isBinaryFileSync`. Binary files emit only the `file=` MD5 line.
 
 ## [0.39.0] (2026-04-23)
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
 ## [Unreleased]
+## [0.40.0] (2026-04-28)
 ### Fixed
 - `WfpCalculator` no longer crashes with `RangeError: Invalid array length` when fingerprinting large binary files.
 - `scanoss-js wfp` CLI now uses `ScanFilter` instead of `DependencyFilter` when building the file list
@@ -304,3 +305,5 @@ All notable changes to this project will be documented in this file. See [standa
 ### [0.37.0](https://github.com/scanoss/scanoss.js/compare/v0.36.0...v0.37.0) (2026-03-02)
 ### [0.38.0](https://github.com/scanoss/scanoss.js/compare/v0.37.0...v0.38.0) (2026-03-12)
 ### [0.38.1](https://github.com/scanoss/scanoss.js/compare/v0.38.0...v0.38.1) (2026-04-08)
+### [0.39.0](https://github.com/scanoss/scanoss.js/compare/v0.38.1...v0.39.0) (2026-04-23)
+### [0.40.0](https://github.com/scanoss/scanoss.js/compare/v0.39.0...v0.40.0) (2026-04-28)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scanoss",
-  "version": "0.39.0",
+  "version": "0.40.0",
   "description": "The SCANOSS JS package provides a simple, easy to consume module for interacting with SCANOSS APIs/Engine.",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/cli/commands/wfp.ts
+++ b/src/cli/commands/wfp.ts
@@ -8,7 +8,7 @@ import { IWfpProviderInput } from '../../sdk/scanner/WfpProvider/WfpProvider';
 import { WfpCalculator } from '../../sdk/scanner/WfpProvider/WfpCalculator/WfpCalculator';
 import { FingerprintPackage } from '../../sdk/scanner/WfpProvider/FingerprintPackage';
 import { Tree } from '../../sdk/tree/Tree';
-import { DependencyFilter } from '../../sdk/tree/Filters/DependencyFilter';
+import { ScanFilter } from '../../sdk/tree/Filters/ScanFilter';
 
 
 export async function wfpHandler(rootPath: string, options: any): Promise<void> {
@@ -22,7 +22,7 @@ export async function wfpHandler(rootPath: string, options: any): Promise<void> 
   if (pathIsFolder) {
     const tree = new Tree(rootPath);
     tree.build();
-    filesToFingerprint = tree.getFileList(new DependencyFilter(""));
+    filesToFingerprint = tree.getFileList(new ScanFilter(""));
   } else {
     filesToFingerprint.push(rootPath)
   }

--- a/src/sdk/scanner/Scannable/ScannableItem.ts
+++ b/src/sdk/scanner/Scannable/ScannableItem.ts
@@ -14,12 +14,15 @@ export class ScannableItem {
 
   private lineOffset: number;
 
-  constructor(content: Buffer, contentSource: string, winnowingMode: any, maxSizeWfp: number) {
+  private isBinary: boolean;
+
+  constructor(content: Buffer, contentSource: string, winnowingMode: any, maxSizeWfp: number, isBinary = false) {
     this.contentSource = contentSource;
     this.content = content;
     this.winnowingMode = winnowingMode;
     this.maxSizeWfp = maxSizeWfp;
     this.lineOffset = 0;
+    this.isBinary = isBinary;
   }
 
   public getContent() {

--- a/src/sdk/scanner/WfpProvider/WfpCalculator/WfpCalculator.ts
+++ b/src/sdk/scanner/WfpProvider/WfpCalculator/WfpCalculator.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import { isBinaryFileSync } from 'isbinaryfile';
 import { Worker } from 'worker_threads';
 
 import { ScannableItem } from '../../Scannable/ScannableItem';
@@ -19,18 +20,21 @@ parentPort.on('message', async (scannableItem) => {
     fingerprint = wfp_for_content(
       scannableItem.content,
       scannableItem.contentSource,
-      scannableItem.maxSizeWfp
+      scannableItem.maxSizeWfp,
+      scannableItem.isBinary
     );
   } else if (scannableItem.winnowingMode === "FULL_WINNOWING_HPSM") {
     fingerprint = wfp_hpsm_for_content(
       scannableItem.content,
       scannableItem.contentSource,
-      scannableItem.maxSizeWfp
+      scannableItem.maxSizeWfp,
+      scannableItem.isBinary
     );
   } else if (scannableItem.winnowingMode === "WINNOWING_ONLY_MD5") {
     fingerprint = wfp_only_md5(
       scannableItem.content,
-      scannableItem.contentSource
+      scannableItem.contentSource,
+      scannableItem.isBinary
     );
   }
 
@@ -293,18 +297,25 @@ function join_wfp_hpsm(wfp, hpsm) {
  * @param {Buffer} content
  * @param {string} contentSource
  * @param {number} maxSize
+ * @param {boolean} isBinary When true, HPSM and snippet winnowing are skipped (binary content has no line/code semantics)
  * @returns {string}
  */
-function wfp_hpsm_for_content(content, contentSource, maxSize) {
-  let wfp = wfp_for_content(content, contentSource, maxSize)
+function wfp_hpsm_for_content(content, contentSource, maxSize, isBinary) {
+  let wfp = wfp_for_content(content, contentSource, maxSize, isBinary)
+  if (isBinary) return truncate_string(wfp, maxSize)
   let hpsm = calc_hpsm(content)   //Returns a string
   let wfp_hpsm_joined = join_wfp_hpsm(wfp, hpsm)
   return truncate_string(wfp_hpsm_joined, maxSize)
 }
 
-function wfp_for_content(content, contentSource, maxSize) {
-  let wfp = wfp_only_md5(content, contentSource);
-  wfp += calc_wfp(content, maxSize);
+// Snippet winnowing and HPSM are line/code semantics — meaningless on
+// binary content (random bytes produce noise grams). Binary files emit
+// only the file= MD5 line, matching the behavior of WINNOWING_ONLY_MD5.
+function wfp_for_content(content, contentSource, maxSize, isBinary) {
+  let wfp = wfp_only_md5(content, contentSource, isBinary);
+  if (!isBinary) {
+    wfp += calc_wfp(content, maxSize);
+  }
   return wfp;
 }
 
@@ -413,14 +424,17 @@ function calculate_opposite_line_ending_hash(contents) {
   return crypto.createHash('md5').update(opposite_contents).digest('hex');
 }
 
-function wfp_only_md5(contents, contentSource) {
+function wfp_only_md5(contents, contentSource, isBinary) {
   const file_md5 = crypto.createHash('md5').update(contents).digest('hex');
   let wfp = 'file=' + String(file_md5) + ',' + String(contents.length) + ',' + String(contentSource)+ String.fromCharCode(10);
 
-  // Calculate and add opposite line ending hash if applicable
-  const opposite_hash = calculate_opposite_line_ending_hash(contents);
-  if (opposite_hash !== null) {
-    wfp += 'fh2=' + String(opposite_hash) + String.fromCharCode(10);
+  // fh2 has no meaning on binary content (no line endings to flip) and the
+  // normalization loop blows past V8 limits on large buffers.
+  if (!isBinary) {
+    const opposite_hash = calculate_opposite_line_ending_hash(contents);
+    if (opposite_hash !== null) {
+      wfp += 'fh2=' + String(opposite_hash) + String.fromCharCode(10);
+    }
   }
 
   return wfp;
@@ -578,6 +592,7 @@ export class WfpCalculator extends WfpProvider {
     const path = this.fileList[this.fileListIndex];
     const contentSource = path.replace(`${this.folderRoot}`, '');
     const content = await this.readFile(path);
+    const isBinary = content.length > 0 && isBinaryFileSync(path);
       this.fileListIndex += 1;
       if (!(this.fileListIndex % this.scannerCfg.WINNOWING_REPORT_STATUS_AFTER_X))
         this.emit(
@@ -589,7 +604,8 @@ export class WfpCalculator extends WfpProvider {
         content,
         contentSource,
         this.winnowingMode,
-        this.scannerCfg.WFP_FILE_MAX_SIZE
+        this.scannerCfg.WFP_FILE_MAX_SIZE,
+        isBinary
       );
 
       if (this.headerFilter && content.length > 0) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved crashes when fingerprinting large binary files
  * Fixed invalid array length errors during scanning operations

* **Improvements**
  * Implemented binary file detection to optimize fingerprint calculations
  * Binary content now skips redundant hash computations for improved performance

* **Chores**
  * Version bumped to 0.40.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->